### PR TITLE
feat: set background to brand blue

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,22 @@
 <html>
 <head>
   <title>Ottos Test Web</title>
+  <style>
+    body {
+      background-color: #004aad;
+      color: #ffffff;
+      font-family: Arial, sans-serif;
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+    p {
+      margin: 0.5rem 0;
+    }
+  </style>
 </head>
 <body>
   <p>Content generated for Otto blue.5</p>


### PR DESCRIPTION
## Summary
- add global styles to set background color to Otto blue (#004aad)
- adjust typography to keep text legible on the new blue background

Closes #2

## Testing
- manual: opened index.html in browser and verified page background is #004aad and text is readable