### PR TITLE
docs: add preview environment link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Simple GitHub Pages site used for testing the OpenClaw agent.
 ## Live Site
 https://arminpressler.github.io/Ottos_test_web/
 
+## Preview Environment
+Latest staging build from the `preview` branch:
+https://htmlpreview.github.io/?https://github.com/arminpressler/Ottos_test_web/blob/preview/index.html
+
 ## Branch & Deployment Workflow
 
 The repository now uses a permanent `preview` branch to stage changes before they reach `main` (the published GitHub Pages site).


### PR DESCRIPTION
## Summary
- document a direct preview link for the staging branch

## Changes
- add a "Preview Environment" section to README pointing at htmlpreview for the  branch

## Testing
- [x] Manual QA on preview branch (link renders in README)
- [ ] Automated tests (not applicable)

Relates to #8