### PR TITLE
ci: enforce preview base branch

### DIFF
--- a/.github/workflows/preview-branch-check.yml
+++ b/.github/workflows/preview-branch-check.yml
@@ -1,0 +1,24 @@
+name: enforce-preview-base
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  check-base-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure PR targets preview or is a preview promotion
+        run: |
+          BASE="${{ github.event.pull_request.base.ref }}"
+          HEAD="${{ github.event.pull_request.head.ref }}"
+          if [ "$BASE" = "preview" ]; then
+            echo "Base branch is preview ✔"
+            exit 0
+          fi
+          if [ "$BASE" = "main" ] && [ "$HEAD" = "preview" ]; then
+            echo "Preview promotion into main ✔"
+            exit 0
+          fi
+          echo "Pull requests must target preview (or be preview → main promotions)." >&2
+          exit 1


### PR DESCRIPTION
## Summary
- add GitHub Actions check ensuring PRs target preview or are preview→main promotions

## Changes
- add enforce-preview-base workflow to block incorrect base branches

## Testing
- [x] Workflow lint via GitHub Actions schema (leverages GA validation)
- [ ] Manual run will execute on PR open

Fixes #8