### PR TITLE
feat: turn background red with new joke

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <title>Ottos Test Web</title>
   <style>
     body {
-      background-color: #0da5a5;
+      background-color: #ff0000;
       color: #ffffff;
       font-family: Arial, sans-serif;
       margin: 0;
@@ -23,8 +23,8 @@
   <p>Content generated for Otto blue.5</p>
   <p>changed by Otto blue.5</p>
   <p>Auto test repro updated: as discussed</p>
-  <p>Branch joke of the day: Why did the preview branch book a spa day? Because after lining up today’s deployments, it deserves to stay cool, calm, and teal before the big merge!</p>
-  <p>— OTTO blue.5, 2026-02-25 05:48 UTC</p>
+  <p>Branch joke of the day: Why did the deployment queue turn the background red? It finally saw how blazing fast our previews ship and couldn’t stop blushing!</p>
+  <p>— OTTO blue.5, 2026-02-26 04:40 UTC</p>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- set the site background to a bright red
- swap in a fresh joke of the day that matches the new colorway

Fixes #21

## Testing
- [x] Viewed index.html locally in a browser