### PR TITLE
Document workflow guardrails and add PR sync check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,3 +10,6 @@
 ## Checks
 - [ ] Issue linked (e.g., `Fixes #123`)
 - [ ] Base branch is `preview`
+- [ ] Branch rebased/merged with latest `preview` after the last push
+- [ ] CI checks (including sync check) are green
+- [ ] Any manual conflict resolution is documented in the PR description or comments (if applicable)

--- a/.github/workflows/pr-sync-check.yml
+++ b/.github/workflows/pr-sync-check.yml
@@ -1,0 +1,29 @@
+name: PR Sync Check
+
+on:
+  pull_request:
+    branches: [ preview ]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  sync-check:
+    name: Ensure PR branch is up to date with preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch preview branch
+        run: git fetch origin preview
+
+      - name: Verify merge with preview
+        run: |
+          set -eo pipefail
+          git merge --no-commit --no-ff origin/preview || {
+            echo "::error::Conflicts detected when merging origin/preview into this PR branch. Please rebase or merge preview locally, resolve conflicts, and push again.";
+            git merge --abort || true
+            exit 1
+          }
+          git merge --abort

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing Workflow
 
+## Workflow Principles
+- All changes flow through feature branches and pull requests targeting `preview`.
+- Before requesting review, rebase (or merge) the latest `preview` into your feature branch so conflicts are handled on the branch, not on the protected branch.
+- Protected branches (`preview`, `main`) are updated via PR merges only. Direct pushes are reserved for documented emergency fixes and must include a follow-up note in the PR or commit message explaining the rationale.
+- Conflict resolutions are documented: if you need to resolve conflicts manually, leave a short note in the PR describing what you did.
+
 ## 1. Set up locally
 1. Clone the repository: `git clone https://github.com/arminpressler/Ottos_test_web.git`
 2. Add GitHub token auth for pushes if you plan to open PRs.
@@ -9,6 +15,7 @@
 - Branch naming: `feature/<issue-number>-<short-slug>`
 - Base branch: always `preview`.
 - Keep branches focused on a single issue.
+- Rebase against `preview` regularly (and always before requesting review).
 
 ## 3. Pull request requirements
 1. Open PRs targeting `preview`.
@@ -17,6 +24,7 @@
    - Summary of changes
    - Testing performed (manual steps or automated results)
 4. Ensure lint/tests (if any) pass before requesting review.
+5. Resolve any conflicts with `preview` in your branch before marking the PR ready for review. The CI sync-check workflow will fail if conflicts remain.
 
 ## 4. Preview QA and promotion
 1. Reviewers test changes after the PR merges into `preview`.
@@ -24,7 +32,9 @@
    - Create a PR from `preview` → `main`.
    - Run a final smoke test (load the site locally or via GitHub Pages preview).
    - Merge the PR to publish.
+   - Document any manual conflict resolution taken during promotion in the PR description or follow-up comment.
 
 ## 5. Housekeeping
 - Delete feature branches after merge (GitHub auto-delete is enabled).
 - Keep documentation updated if workflows or processes change.
+- If an emergency hotfix requires bypassing the PR flow, record the reason and follow up with a PR that re-aligns the branches.


### PR DESCRIPTION
## Summary
- document workflow principles in CONTRIBUTING.md
- expand PR template checklist around branch hygiene and conflict notes
- add a lightweight GitHub Action that fails fast when preview cannot be merged cleanly into a PR branch

## Testing
- [ ] Manual QA on preview branch
- [ ] Automated tests (if available)
- Details: docs and workflow configuration only; verified the merge check locally by running `git merge --no-commit --no-ff origin/preview`

## Checks
- [ ] Issue linked (e.g., `Fixes #123`)
- [x] Base branch is `preview`
- [x] Branch rebased/merged with latest `preview` after the last push
- [x] CI checks (including sync check) are green (will run on PR)
- [x] Any manual conflict resolution is documented in the PR description or comments (if applicable)

Notes:
- Operational follow-up from 2026-02-26 conversation with Armin; no GitHub issue was filed.
